### PR TITLE
fix: clarify dive-prep is agent flow, not CLI command

### DIFF
--- a/codex-skill/SKILL.md
+++ b/codex-skill/SKILL.md
@@ -213,23 +213,25 @@ fi
 
 Start a focused work session with explicit intent. This is the **recommended way to begin any work**.
 
+This is a shortcut to `$wm dive [intent]` - see that skill for the full agent flow.
+
 **Intent options:**
 - `fix` - Bug fix session
 - `plan` - Design/architecture work
 - `explore` - Understanding code
 - `ship` - Getting changes merged
 
-**Run:**
+**Quick version:**
+
+1. Gather context:
 ```bash
-wm dive-prep --intent <intent>
+git status && git log --oneline -3
+wm compile
 ```
 
-This creates `.wm/dive_context.md` with:
-- Your explicit intent
-- Relevant context from working memory
-- Suggested workflow for this type of work
+2. Write `.wm/dive_context.md` with intent, context, and workflow
 
-**Tell user:** "Dive prepped. Intent: [intent]. Context loaded to .wm/dive_context.md"
+3. Confirm: "Dive prepped. Intent: [intent]. Ready to work."
 
 **No dive is too small.** Even a quick bug fix benefits from 30 seconds of explicit intent.
 

--- a/codex-skill/wm/SKILL.md
+++ b/codex-skill/wm/SKILL.md
@@ -9,25 +9,76 @@ Captures tacit knowledge from sessions and provides relevant context for current
 
 ## $wm dive [intent]
 
-**Start every session with a dive.** Prepares context based on your intent.
+**Start every session with a dive.** This is an agent flow, not a single CLI command.
 
 **Intent options:**
 - `fix` - Bug fix session
 - `plan` - Design/architecture work
 - `explore` - Understanding code
 - `ship` - Getting changes merged
+- `review` - Reflect on recent work
 
-**Run:**
-```bash
-wm dive prep --intent <intent>
+### Dive Prep Flow
+
+**Step 1:** If intent not provided, ask user:
+```
+What's your intent for this session?
+[ ] fix - Fix a bug or issue
+[ ] plan - Design an approach
+[ ] explore - Understand something
+[ ] ship - Get something deployed
 ```
 
-This creates `.wm/dive_context.md` with:
-- Your explicit intent
-- Relevant context from accumulated knowledge
-- Suggested workflow
+**Step 2:** Gather context from available sources:
+```bash
+# Check git state
+git status
+git log --oneline -5
 
-**Tell user:** "Dive prepped. Intent: [intent]. Context in .wm/dive_context.md"
+# Check for project instructions
+cat AGENTS.md 2>/dev/null || cat CLAUDE.md 2>/dev/null
+
+# Get accumulated knowledge
+wm compile
+```
+
+**Step 3:** Build and write the dive manifest:
+
+Create `.wm/dive_context.md` with:
+```markdown
+# Dive Session
+
+**Intent:** [intent]
+**Started:** [timestamp]
+
+## Context
+[Project instructions, git state, relevant knowledge]
+
+## Focus
+[What we're working on]
+
+## Workflow
+[Steps for this intent type]
+```
+
+**Step 4:** Confirm to user:
+```
+✓ Dive session prepared
+  Intent: [intent]
+  Context: .wm/dive_context.md
+
+Ready to work.
+```
+
+### Named Dive Preps (CLI)
+
+After creating a dive context, save it as a named prep:
+```bash
+wm dive save my-feature    # Save current context as named prep
+wm dive list               # List all preps (* marks current)
+wm dive switch my-feature  # Switch to a named prep
+wm dive show               # Show current prep content
+```
 
 **No dive is too small.** Even a quick bug fix benefits from 30 seconds of explicit intent.
 


### PR DESCRIPTION
## Summary

Fixes the Codex skills to accurately describe the dive-prep flow.

### Problem

The skills referenced `wm dive-prep --intent <intent>` which doesn't exist as a CLI command. The dive-prep is an **agent flow** where the AI:
1. Asks for intent
2. Gathers context (git, project files, wm compile)
3. Writes `.wm/dive_context.md`
4. Confirms to user

### Changes

**$wm dive:**
- Now describes the full agent flow with clear steps
- Documents the actual CLI commands for managing named preps (`wm dive save/list/switch`)

**$bottle dive:**
- Points to `$wm dive` for the full flow
- Provides quick version for reference

## Test plan
- [x] Removed references to non-existent CLI commands
- [x] Agent flow matches what wm plugin/agents/dive-prep.md describes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the dive workflow as a multi-step agent flow with explicit prompts and outputs at each stage.
  * Simplified quick-start instructions with reorganized context gathering steps.
  * Added a new "review" option to intent choices.
  * Introduced named dive preps feature for saving and switching between dive configurations.
  * Updated context file structure to include Focus and Workflow sections.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->