### PR TITLE
feat: add bottle integrate command

### DIFF
--- a/src/commands/install.rs
+++ b/src/commands/install.rs
@@ -58,6 +58,7 @@ pub fn run(bottle: &str, yes: bool) -> Result<()> {
         installed_at: Utc::now(),
         tools: tool_states,
         mode: Mode::Managed,
+        integrations: HashMap::new(),
     };
     state.save().map_err(|e| BottleError::Other(format!("Failed to save state: {}", e)))?;
 

--- a/src/commands/integrate.rs
+++ b/src/commands/integrate.rs
@@ -1,0 +1,181 @@
+use crate::error::{BottleError, Result};
+use crate::integrate::{self, Platform};
+use crate::manifest::state::{BottleState, IntegrationState};
+use crate::ui;
+use chrono::Utc;
+use console::style;
+
+/// Add, remove, or list platform integrations
+pub fn run(platform: Option<Platform>, list: bool, remove: bool) -> Result<()> {
+    // Must have a bottle installed
+    let state = BottleState::load().ok_or(BottleError::NoBottleInstalled)?;
+
+    // Handle --list
+    if list {
+        return show_integrations(&state);
+    }
+
+    // Platform is required for add/remove
+    let platform = platform.ok_or_else(|| {
+        BottleError::Other(
+            "Platform required. Use 'bottle integrate claude_code', 'opencode', or 'codex'.\n\
+             Use 'bottle integrate --list' to see available integrations."
+                .to_string(),
+        )
+    })?;
+
+    if remove {
+        remove_integration(&state, platform)
+    } else {
+        add_integration(&state, platform)
+    }
+}
+
+/// Show available and installed integrations
+fn show_integrations(state: &BottleState) -> Result<()> {
+    println!();
+    println!("{}:", style("Platform Integrations").bold());
+    println!();
+
+    let detections = integrate::detect_platforms();
+
+    for detection in &detections {
+        let platform = detection.platform;
+        let installed = state.integrations.contains_key(platform.key());
+        let detected = detection.detected;
+
+        let status = if installed {
+            style("installed").green()
+        } else if detected {
+            style("detected").yellow()
+        } else {
+            style("not detected").dim()
+        };
+
+        let hint = if detected {
+            format!("({})", detection.detection_hint)
+        } else {
+            format!("({} not found)", detection.detection_hint)
+        };
+
+        println!(
+            "  {:<12} {} {}",
+            platform.display_name(),
+            status,
+            style(hint).dim()
+        );
+    }
+
+    println!();
+    println!("{}:", style("Commands").dim());
+    println!(
+        "  {} {} - Add an integration",
+        style("bottle integrate").cyan(),
+        style("<platform>").dim()
+    );
+    println!(
+        "  {} {} - Remove an integration",
+        style("bottle integrate --remove").cyan(),
+        style("<platform>").dim()
+    );
+    println!();
+
+    Ok(())
+}
+
+/// Add a platform integration
+fn add_integration(state: &BottleState, platform: Platform) -> Result<()> {
+    // Check if already installed
+    if state.integrations.contains_key(platform.key()) {
+        ui::print_warning(&format!("{} integration is already installed.", platform));
+        return Ok(());
+    }
+
+    // Warn if not detected (but allow anyway)
+    let detections = integrate::detect_platforms();
+    let detection = detections.iter().find(|d| d.platform == platform);
+    if let Some(d) = detection {
+        if !d.detected {
+            ui::print_warning(&format!(
+                "{} not detected ({} not found). Installing anyway.",
+                platform, d.detection_hint
+            ));
+        }
+    }
+
+    // Install
+    println!(
+        "Installing {} integration...",
+        style(platform.display_name()).cyan()
+    );
+
+    integrate::install(platform)?;
+
+    // Update state
+    let mut new_state = state.clone();
+    new_state.integrations.insert(
+        platform.key().to_string(),
+        IntegrationState {
+            installed_at: Utc::now(),
+        },
+    );
+    new_state
+        .save()
+        .map_err(|e| BottleError::Other(format!("Failed to save state: {}", e)))?;
+
+    // Success message with platform-specific hints
+    println!();
+    ui::print_success(&format!("{} integration installed.", platform));
+
+    match platform {
+        Platform::ClaudeCode => {
+            println!(
+                "  The {} plugin is now available.",
+                style("/bottle:").cyan()
+            );
+        }
+        Platform::OpenCode => {
+            println!("  Restart OpenCode to load the bottle plugin.");
+        }
+        Platform::Codex => {
+            println!(
+                "  Use {} commands in Codex.",
+                style("$bottle").cyan()
+            );
+        }
+    }
+    println!();
+
+    Ok(())
+}
+
+/// Remove a platform integration
+fn remove_integration(state: &BottleState, platform: Platform) -> Result<()> {
+    // Check if installed
+    if !state.integrations.contains_key(platform.key()) {
+        ui::print_warning(&format!("{} integration is not installed.", platform));
+        return Ok(());
+    }
+
+    // Remove
+    println!(
+        "Removing {} integration...",
+        style(platform.display_name()).cyan()
+    );
+
+    integrate::remove(platform)?;
+
+    // Update state
+    let mut new_state = state.clone();
+    new_state.integrations.remove(platform.key());
+    new_state
+        .save()
+        .map_err(|e| BottleError::Other(format!("Failed to save state: {}", e)))?;
+
+    // Success
+    println!();
+    ui::print_success(&format!("{} integration removed.", platform));
+    println!();
+
+    Ok(())
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -3,6 +3,7 @@ pub mod create;
 pub mod diff;
 pub mod eject;
 pub mod install;
+pub mod integrate;
 pub mod list;
 pub mod release;
 pub mod status;

--- a/src/commands/switch.rs
+++ b/src/commands/switch.rs
@@ -56,13 +56,14 @@ pub fn run(bottle: &str, yes: bool) -> Result<()> {
     // 9. Handle plugins
     update_plugins(&new_manifest)?;
 
-    // 10. Save new state
+    // 10. Save new state (preserve integrations across bottle switches)
     let new_state = BottleState {
         bottle: new_manifest.name.clone(),
         bottle_version: new_manifest.version.clone(),
         installed_at: Utc::now(),
         tools: tool_states,
         mode: Mode::Managed,
+        integrations: state.integrations.clone(),
     };
     new_state
         .save()

--- a/src/commands/update.rs
+++ b/src/commands/update.rs
@@ -64,13 +64,14 @@ pub fn run(yes: bool) -> Result<()> {
         apply_updates(&state, &changes)?
     };
 
-    // 7. Save updated state
+    // 7. Save updated state (preserve integrations across updates)
     let new_state = BottleState {
         bottle: state.bottle.clone(),
         bottle_version: latest.version.clone(),
         installed_at: state.installed_at,
         tools: updated_tools,
         mode: state.mode.clone(),
+        integrations: state.integrations.clone(),
     };
     new_state
         .save()

--- a/src/integrate/claude_code.rs
+++ b/src/integrate/claude_code.rs
@@ -1,0 +1,80 @@
+//! Claude Code integration
+//!
+//! Installs/removes the bottle plugin for Claude Code.
+
+use crate::error::{BottleError, Result};
+use std::process::Command;
+
+/// Marketplace and plugin name for Claude Code integration
+const MARKETPLACE: &str = "cloud-atlas-ai/bottle";
+const PLUGIN: &str = "bottle";
+
+/// Check if Claude Code is detected (has config directory)
+pub fn is_detected() -> bool {
+    dirs::home_dir()
+        .map(|h| h.join(".claude").exists())
+        .unwrap_or(false)
+}
+
+/// Check if the bottle plugin is installed in Claude Code
+#[allow(dead_code)]
+pub fn is_installed() -> bool {
+    Command::new("claude")
+        .args(["plugin", "list"])
+        .output()
+        .map(|output| {
+            let stdout = String::from_utf8_lossy(&output.stdout);
+            // AIDEV-NOTE: This checks for the plugin name in the list output.
+            // The exact format depends on claude CLI output. May need adjustment.
+            stdout.contains(PLUGIN) && stdout.contains(MARKETPLACE)
+        })
+        .unwrap_or(false)
+}
+
+/// Install the bottle plugin for Claude Code
+pub fn install() -> Result<()> {
+    let status = Command::new("claude")
+        .args([
+            "plugin",
+            "install",
+            &format!("{}@{}", PLUGIN, MARKETPLACE),
+        ])
+        .status()
+        .map_err(|e| BottleError::InstallError {
+            tool: "claude_code integration".to_string(),
+            reason: format!("Failed to run claude plugin install: {}", e),
+        })?;
+
+    if status.success() {
+        Ok(())
+    } else {
+        Err(BottleError::InstallError {
+            tool: "claude_code integration".to_string(),
+            reason: format!("claude plugin install exited with code {}", status),
+        })
+    }
+}
+
+/// Remove the bottle plugin from Claude Code
+pub fn remove() -> Result<()> {
+    let status = Command::new("claude")
+        .args([
+            "plugin",
+            "uninstall",
+            &format!("{}@{}", PLUGIN, MARKETPLACE),
+        ])
+        .status()
+        .map_err(|e| BottleError::InstallError {
+            tool: "claude_code integration".to_string(),
+            reason: format!("Failed to run claude plugin uninstall: {}", e),
+        })?;
+
+    if status.success() {
+        Ok(())
+    } else {
+        Err(BottleError::InstallError {
+            tool: "claude_code integration".to_string(),
+            reason: format!("claude plugin uninstall exited with code {}", status),
+        })
+    }
+}

--- a/src/integrate/codex.rs
+++ b/src/integrate/codex.rs
@@ -1,0 +1,171 @@
+//! Codex integration
+//!
+//! Installs/removes the bottle skill for Codex.
+
+use crate::error::{BottleError, Result};
+use std::fs;
+use std::path::PathBuf;
+
+/// Skill directory name
+const SKILL_DIR: &str = "bottle";
+
+/// Get the Codex skills directory path
+fn skills_dir() -> Option<PathBuf> {
+    dirs::home_dir().map(|h| h.join(".codex").join("skills"))
+}
+
+/// Get the bottle skill path
+fn skill_path() -> Option<PathBuf> {
+    skills_dir().map(|s| s.join(SKILL_DIR))
+}
+
+/// Check if Codex is detected (has config directory)
+pub fn is_detected() -> bool {
+    dirs::home_dir()
+        .map(|h| h.join(".codex").exists())
+        .unwrap_or(false)
+}
+
+/// Check if the bottle skill is installed in Codex
+#[allow(dead_code)]
+pub fn is_installed() -> bool {
+    skill_path()
+        .map(|p| p.exists())
+        .unwrap_or(false)
+}
+
+/// Install the bottle skill for Codex
+/// AIDEV-NOTE: Creates a minimal SKILL.md that invokes the bottle CLI.
+/// The actual skill content will be enhanced as part of kk-c0jl task.
+pub fn install() -> Result<()> {
+    let skills_path = skills_dir().ok_or_else(|| BottleError::InstallError {
+        tool: "codex integration".to_string(),
+        reason: "Could not determine Codex skills directory".to_string(),
+    })?;
+
+    // Create skills directory if needed
+    fs::create_dir_all(&skills_path).map_err(|e| BottleError::InstallError {
+        tool: "codex integration".to_string(),
+        reason: format!("Failed to create skills directory: {}", e),
+    })?;
+
+    let bottle_skill_path = skills_path.join(SKILL_DIR);
+
+    // Create skill directory
+    fs::create_dir_all(&bottle_skill_path).map_err(|e| BottleError::InstallError {
+        tool: "codex integration".to_string(),
+        reason: format!("Failed to create bottle skill directory: {}", e),
+    })?;
+
+    // Write SKILL.md
+    let skill_content = r#"# Bottle
+
+Manage the Cloud Atlas AI tool stack.
+
+## Commands
+
+All commands invoke the `bottle` CLI. Ensure bottle is installed.
+
+### $bottle status
+
+Show current bottle state.
+
+```bash
+bottle status
+```
+
+### $bottle install <name>
+
+Install a bottle (stable, edge, or bespoke).
+
+```bash
+bottle install stable
+bottle install edge
+```
+
+### $bottle update
+
+Update to the latest bottle snapshot.
+
+```bash
+bottle update
+```
+
+### $bottle switch <name>
+
+Switch to a different bottle.
+
+```bash
+bottle switch edge
+```
+
+### $bottle list
+
+List available bottles.
+
+```bash
+bottle list
+```
+
+### $bottle eject
+
+Exit bottle management, keep tools.
+
+```bash
+bottle eject
+```
+
+### $bottle integrate <platform>
+
+Add a platform integration.
+
+```bash
+bottle integrate opencode
+bottle integrate codex
+bottle integrate claude_code
+```
+
+### $bottle integrate --remove <platform>
+
+Remove a platform integration.
+
+```bash
+bottle integrate --remove codex
+```
+
+### $bottle integrate --list
+
+Show available and installed integrations.
+
+```bash
+bottle integrate --list
+```
+"#;
+
+    fs::write(bottle_skill_path.join("SKILL.md"), skill_content).map_err(|e| {
+        BottleError::InstallError {
+            tool: "codex integration".to_string(),
+            reason: format!("Failed to write SKILL.md: {}", e),
+        }
+    })?;
+
+    Ok(())
+}
+
+/// Remove the bottle skill from Codex
+pub fn remove() -> Result<()> {
+    let Some(path) = skill_path() else {
+        return Ok(()); // No path, nothing to remove
+    };
+
+    if !path.exists() {
+        return Ok(()); // Already removed
+    }
+
+    fs::remove_dir_all(&path).map_err(|e| BottleError::InstallError {
+        tool: "codex integration".to_string(),
+        reason: format!("Failed to remove bottle skill: {}", e),
+    })?;
+
+    Ok(())
+}

--- a/src/integrate/mod.rs
+++ b/src/integrate/mod.rs
@@ -1,0 +1,98 @@
+pub mod claude_code;
+pub mod codex;
+pub mod opencode;
+
+use crate::error::Result;
+use std::fmt;
+
+/// Supported platform integrations
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Platform {
+    ClaudeCode,
+    OpenCode,
+    Codex,
+}
+
+impl Platform {
+    /// Get the state key for this platform (snake_case)
+    pub fn key(&self) -> &'static str {
+        match self {
+            Platform::ClaudeCode => "claude_code",
+            Platform::OpenCode => "opencode",
+            Platform::Codex => "codex",
+        }
+    }
+
+    /// Get display name for this platform
+    pub fn display_name(&self) -> &'static str {
+        match self {
+            Platform::ClaudeCode => "Claude Code",
+            Platform::OpenCode => "OpenCode",
+            Platform::Codex => "Codex",
+        }
+    }
+}
+
+impl fmt::Display for Platform {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.display_name())
+    }
+}
+
+/// Detection result for a platform
+#[derive(Debug)]
+pub struct DetectionResult {
+    pub platform: Platform,
+    pub detected: bool,
+    pub detection_hint: String,
+}
+
+/// Detect which platforms are available on this system
+pub fn detect_platforms() -> Vec<DetectionResult> {
+    vec![
+        DetectionResult {
+            platform: Platform::ClaudeCode,
+            detected: claude_code::is_detected(),
+            detection_hint: "~/.claude/".to_string(),
+        },
+        DetectionResult {
+            platform: Platform::OpenCode,
+            detected: opencode::is_detected(),
+            detection_hint: "opencode.json".to_string(),
+        },
+        DetectionResult {
+            platform: Platform::Codex,
+            detected: codex::is_detected(),
+            detection_hint: "~/.codex/".to_string(),
+        },
+    ]
+}
+
+/// Install an integration for a platform
+pub fn install(platform: Platform) -> Result<()> {
+    match platform {
+        Platform::ClaudeCode => claude_code::install(),
+        Platform::OpenCode => opencode::install(),
+        Platform::Codex => codex::install(),
+    }
+}
+
+/// Remove an integration for a platform
+pub fn remove(platform: Platform) -> Result<()> {
+    match platform {
+        Platform::ClaudeCode => claude_code::remove(),
+        Platform::OpenCode => opencode::remove(),
+        Platform::Codex => codex::remove(),
+    }
+}
+
+/// Check if an integration is currently installed (filesystem check)
+/// AIDEV-NOTE: Kept for future use in `bottle status` to verify state matches reality
+#[allow(dead_code)]
+pub fn is_installed(platform: Platform) -> bool {
+    match platform {
+        Platform::ClaudeCode => claude_code::is_installed(),
+        Platform::OpenCode => opencode::is_installed(),
+        Platform::Codex => codex::is_installed(),
+    }
+}

--- a/src/integrate/opencode.rs
+++ b/src/integrate/opencode.rs
@@ -1,0 +1,158 @@
+//! OpenCode integration
+//!
+//! Adds/removes the bottle plugin to opencode.json.
+//!
+//! AIDEV-NOTE: Config file resolution is cwd-first, then home directory.
+//! This means `bottle integrate opencode` modifies the local project's
+//! opencode.json if it exists, otherwise the global ~/.opencode.json.
+//! This matches how opencode itself resolves config files.
+
+use crate::error::{BottleError, Result};
+use serde_json::{json, Value};
+use std::fs;
+use std::path::PathBuf;
+
+/// NPM package for the OpenCode integration
+const PACKAGE: &str = "@cloud-atlas-ai/bottle";
+
+/// Check if OpenCode is detected (has opencode.json in cwd or home)
+pub fn is_detected() -> bool {
+    get_config_path().is_some()
+}
+
+/// Get the path to opencode.json (cwd first, then home)
+fn get_config_path() -> Option<PathBuf> {
+    // Check current directory first
+    let cwd_config = PathBuf::from("opencode.json");
+    if cwd_config.exists() {
+        return Some(cwd_config);
+    }
+
+    // Check home directory
+    dirs::home_dir()
+        .map(|h| h.join("opencode.json"))
+        .filter(|p| p.exists())
+}
+
+/// Check if the bottle plugin is installed in OpenCode config
+#[allow(dead_code)]
+pub fn is_installed() -> bool {
+    let Some(config_path) = get_config_path() else {
+        return false;
+    };
+
+    let Ok(contents) = fs::read_to_string(&config_path) else {
+        return false;
+    };
+
+    let Ok(config): std::result::Result<Value, _> = serde_json::from_str(&contents) else {
+        return false;
+    };
+
+    // Check if package is in plugins array
+    config
+        .get("plugins")
+        .and_then(|p| p.as_array())
+        .map(|plugins| plugins.iter().any(|p| p.as_str() == Some(PACKAGE)))
+        .unwrap_or(false)
+}
+
+/// Install the bottle plugin into OpenCode config
+pub fn install() -> Result<()> {
+    let config_path = get_config_path().ok_or_else(|| {
+        BottleError::InstallError {
+            tool: "opencode integration".to_string(),
+            reason: "No opencode.json found in current directory or home".to_string(),
+        }
+    })?;
+
+    // Read existing config
+    let contents = fs::read_to_string(&config_path).map_err(|e| BottleError::InstallError {
+        tool: "opencode integration".to_string(),
+        reason: format!("Failed to read opencode.json: {}", e),
+    })?;
+
+    let mut config: Value = serde_json::from_str(&contents).map_err(|e| {
+        BottleError::InstallError {
+            tool: "opencode integration".to_string(),
+            reason: format!("Failed to parse opencode.json: {}", e),
+        }
+    })?;
+
+    // Get or create plugins array
+    let plugins = config
+        .as_object_mut()
+        .ok_or_else(|| BottleError::InstallError {
+            tool: "opencode integration".to_string(),
+            reason: "opencode.json is not an object".to_string(),
+        })?
+        .entry("plugins")
+        .or_insert_with(|| json!([]));
+
+    let plugins_array = plugins.as_array_mut().ok_or_else(|| BottleError::InstallError {
+        tool: "opencode integration".to_string(),
+        reason: "plugins field is not an array".to_string(),
+    })?;
+
+    // Check if already installed
+    if plugins_array.iter().any(|p| p.as_str() == Some(PACKAGE)) {
+        return Ok(()); // Already installed, idempotent
+    }
+
+    // Add our package
+    plugins_array.push(json!(PACKAGE));
+
+    // Write back
+    let updated = serde_json::to_string_pretty(&config).map_err(|e| BottleError::InstallError {
+        tool: "opencode integration".to_string(),
+        reason: format!("Failed to serialize config: {}", e),
+    })?;
+
+    fs::write(&config_path, updated).map_err(|e| BottleError::InstallError {
+        tool: "opencode integration".to_string(),
+        reason: format!("Failed to write opencode.json: {}", e),
+    })?;
+
+    Ok(())
+}
+
+/// Remove the bottle plugin from OpenCode config
+pub fn remove() -> Result<()> {
+    let Some(config_path) = get_config_path() else {
+        return Ok(()); // No config, nothing to remove
+    };
+
+    // Read existing config
+    let contents = fs::read_to_string(&config_path).map_err(|e| BottleError::InstallError {
+        tool: "opencode integration".to_string(),
+        reason: format!("Failed to read opencode.json: {}", e),
+    })?;
+
+    let mut config: Value = serde_json::from_str(&contents).map_err(|e| {
+        BottleError::InstallError {
+            tool: "opencode integration".to_string(),
+            reason: format!("Failed to parse opencode.json: {}", e),
+        }
+    })?;
+
+    // Get plugins array
+    let Some(plugins) = config.get_mut("plugins").and_then(|p| p.as_array_mut()) else {
+        return Ok(()); // No plugins array, nothing to remove
+    };
+
+    // Remove our package
+    plugins.retain(|p| p.as_str() != Some(PACKAGE));
+
+    // Write back
+    let updated = serde_json::to_string_pretty(&config).map_err(|e| BottleError::InstallError {
+        tool: "opencode integration".to_string(),
+        reason: format!("Failed to serialize config: {}", e),
+    })?;
+
+    fs::write(&config_path, updated).map_err(|e| BottleError::InstallError {
+        tool: "opencode integration".to_string(),
+        reason: format!("Failed to write opencode.json: {}", e),
+    })?;
+
+    Ok(())
+}

--- a/src/manifest/state.rs
+++ b/src/manifest/state.rs
@@ -11,6 +11,16 @@ pub struct BottleState {
     pub installed_at: DateTime<Utc>,
     pub tools: HashMap<String, ToolState>,
     pub mode: Mode,
+    /// Platform integrations (Claude Code, OpenCode, Codex)
+    /// AIDEV-NOTE: Optional for backwards compatibility with existing state files
+    #[serde(default)]
+    pub integrations: HashMap<String, IntegrationState>,
+}
+
+/// State for a platform integration
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct IntegrationState {
+    pub installed_at: DateTime<Utc>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]


### PR DESCRIPTION
## Summary

- Adds `bottle integrate` command for managing platform integrations (Claude Code, OpenCode, Codex)
- New `integrate/` module with platform-specific logic for each target
- State tracking for installed integrations with preservation across bottle operations
- Type-safe CLI argument parsing using clap ValueEnum

## Usage

```bash
bottle integrate claude_code      # Add Claude Code integration
bottle integrate opencode         # Add OpenCode integration
bottle integrate codex            # Add Codex integration
bottle integrate --list           # Show available/installed integrations
bottle integrate --remove codex   # Remove an integration
```

## Test plan

- [ ] `bottle integrate --list` shows detection status for all platforms
- [ ] `bottle integrate claude_code` installs the plugin (requires Claude Code installed)
- [ ] `bottle integrate opencode` modifies opencode.json (requires opencode.json present)
- [ ] `bottle integrate codex` creates ~/.codex/skills/bottle/SKILL.md
- [ ] `bottle integrate --remove <platform>` removes the integration
- [ ] Integrations persist across `bottle switch` and `bottle update`
- [ ] State file backwards compatibility (existing state.json loads correctly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added platform integration management with a new `integrate` command.
  * Support for integrating with Claude Code, OpenCode, and Codex.
  * Ability to detect, install, list, and remove platform integrations.
  * Integration state is now preserved across bottle switches and updates.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->