### PR TITLE
Add manifest version update script and improve release docs

### DIFF
--- a/bottles/stable/manifest.json
+++ b/bottles/stable/manifest.json
@@ -14,9 +14,9 @@
   },
   "tools": {
     "ba": "0.2.1",
-    "oh-mcp": "0.3.0",
+    "oh-mcp": "0.3.3",
     "superego": "0.9.0",
-    "wm": "0.2.2"
+    "wm": "0.3.1"
   },
   "opencode_plugins": {
     "@cloud-atlas-ai/bottle": "0.2.6",

--- a/commands/release.md
+++ b/commands/release.md
@@ -17,6 +17,43 @@ bottle release stable -m "Bump superego to 0.9.0"
 ## What it does
 
 1. Runs validation
-2. Checks git status
-3. Creates git tag (e.g., `stable-2026.01.15`)
-4. Pushes tag
+2. Checks git status is clean
+3. Bumps manifest version to today's date
+4. Commits the change
+5. Creates git tag (e.g., `stable-2026.01.15`)
+6. Pushes commit and tag
+
+## Full Release Workflow
+
+To release a bottle with updated tool versions:
+
+```bash
+# 1. Update manifest with latest upstream versions
+./scripts/update-manifest.sh
+
+# 2. Review changes
+git diff bottles/stable/manifest.json
+
+# 3. Release (commits, tags, pushes)
+bottle release stable -m "Update tool versions"
+```
+
+### Preview version changes without applying
+
+```bash
+./scripts/update-manifest.sh --dry-run
+```
+
+## Releasing the bottle CLI itself
+
+To release a new version of the `bottle` binary:
+
+```bash
+# Auto-increment patch version
+./scripts/release.sh
+
+# Or specify version explicitly
+./scripts/release.sh 0.2.0
+```
+
+This updates Cargo.toml, plugin.json, runs tests, commits, tags, and pushes. GitHub Actions then builds binaries and updates homebrew.

--- a/scripts/update-manifest.sh
+++ b/scripts/update-manifest.sh
@@ -1,0 +1,107 @@
+#!/bin/bash
+# Update manifest.json with latest versions from crates.io, npm, and GitHub
+#
+# Usage: ./scripts/update-manifest.sh [--dry-run]
+
+set -e
+
+MANIFEST="bottles/stable/manifest.json"
+DRY_RUN=false
+
+if [ "$1" = "--dry-run" ]; then
+    DRY_RUN=true
+fi
+
+# Colors
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+log() { echo -e "${GREEN}[update]${NC} $1"; }
+warn() { echo -e "${YELLOW}[update]${NC} $1"; }
+
+# Fetch latest version from crates.io
+crate_version() {
+    curl -s "https://crates.io/api/v1/crates/$1" | jq -r '.crate.max_version // "0.0.0"'
+}
+
+# Fetch latest version from npm
+npm_version() {
+    npm view "$1" version 2>/dev/null || echo "0.0.0"
+}
+
+# Fetch version from GitHub raw file (Cargo.toml)
+github_cargo_version() {
+    local repo=$1
+    curl -s "https://raw.githubusercontent.com/$repo/main/Cargo.toml" 2>/dev/null | \
+        grep '^version' | head -1 | sed 's/version = "\(.*\)"/\1/'
+}
+
+# Fetch version from GitHub raw file (package.json)
+github_npm_version() {
+    local repo=$1
+    curl -s "https://raw.githubusercontent.com/$repo/main/package.json" 2>/dev/null | \
+        jq -r '.version // "0.0.0"'
+}
+
+log "Fetching latest versions..."
+
+# Tools (prefer crates.io, fallback to GitHub)
+BA_VERSION=$(crate_version "ba")
+SUPEREGO_VERSION=$(crate_version "superego")
+
+# wm is not on crates.io, use GitHub
+WM_VERSION=$(github_cargo_version "cloud-atlas-ai/wm")
+[ -z "$WM_VERSION" ] && WM_VERSION="0.0.0"
+
+# oh-mcp from GitHub
+OH_MCP_VERSION=$(github_npm_version "cloud-atlas-ai/oh-mcp-server")
+[ -z "$OH_MCP_VERSION" ] && OH_MCP_VERSION="0.0.0"
+
+# OpenCode plugins from npm
+BOTTLE_OC_VERSION=$(npm_version "@cloud-atlas-ai/bottle")
+BA_OC_VERSION=$(npm_version "ba-opencode")
+WM_OC_VERSION=$(npm_version "wm-opencode")
+SUPEREGO_OC_VERSION=$(npm_version "superego-opencode")
+
+echo ""
+log "Latest versions found:"
+echo "  tools:"
+echo "    ba:       $BA_VERSION"
+echo "    wm:       $WM_VERSION"
+echo "    superego: $SUPEREGO_VERSION"
+echo "    oh-mcp:   $OH_MCP_VERSION"
+echo "  opencode_plugins:"
+echo "    @cloud-atlas-ai/bottle: $BOTTLE_OC_VERSION"
+echo "    ba-opencode:            $BA_OC_VERSION"
+echo "    wm-opencode:            $WM_OC_VERSION"
+echo "    superego-opencode:      $SUPEREGO_OC_VERSION"
+echo ""
+
+if [ "$DRY_RUN" = true ]; then
+    log "Dry run - no changes made"
+    exit 0
+fi
+
+# Update manifest using jq
+log "Updating $MANIFEST..."
+
+jq --arg ba "$BA_VERSION" \
+   --arg wm "$WM_VERSION" \
+   --arg sg "$SUPEREGO_VERSION" \
+   --arg oh "$OH_MCP_VERSION" \
+   --arg bottle_oc "$BOTTLE_OC_VERSION" \
+   --arg ba_oc "$BA_OC_VERSION" \
+   --arg wm_oc "$WM_OC_VERSION" \
+   --arg sg_oc "$SUPEREGO_OC_VERSION" \
+   '.tools.ba = $ba |
+    .tools.wm = $wm |
+    .tools.superego = $sg |
+    .tools["oh-mcp"] = $oh |
+    .opencode_plugins["@cloud-atlas-ai/bottle"] = $bottle_oc |
+    .opencode_plugins["ba-opencode"] = $ba_oc |
+    .opencode_plugins["wm-opencode"] = $wm_oc |
+    .opencode_plugins["superego-opencode"] = $sg_oc' \
+   "$MANIFEST" > "$MANIFEST.tmp" && mv "$MANIFEST.tmp" "$MANIFEST"
+
+log "Done!"


### PR DESCRIPTION
## Summary
- Add `scripts/update-manifest.sh` to fetch latest tool versions from crates.io, npm, and GitHub
- Update `bottles/stable/manifest.json` with current versions (wm 0.3.1, oh-mcp 0.3.3)
- Improve `commands/release.md` with full release workflow documentation

## Test plan
- [ ] Run `./scripts/update-manifest.sh --dry-run` to verify version fetching
- [ ] Run `./scripts/update-manifest.sh` to verify manifest update
- [ ] Review updated release docs for clarity

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated tool versions: oh-mcp (0.3.3) and wm (0.3.1).

* **Documentation**
  * Improved release workflow documentation with explicit, granular steps for various release scenarios.

* **Chores**
  * Added automated tooling for manifest version updates and management.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->