### PR TITLE
feat: detect multiple Claude Code directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,15 @@ bottle install stable
 bottle integrate claude_code  # or: codex, opencode
 ```
 
+### Multiple Claude Code Directories
+
+If you have multiple Claude Code directories (e.g., `~/.claude` for personal use and `~/.claude-work` for work), use the `CLAUDE_CONFIG_DIR` environment variable:
+
+```bash
+bottle integrate --list                                      # shows all detected directories
+CLAUDE_CONFIG_DIR=~/.claude-work bottle integrate claude_code  # integrate specific directory
+```
+
 Then initialize in your project:
 ```
 /bottle:init          # Claude Code

--- a/src/commands/integrate.rs
+++ b/src/commands/integrate.rs
@@ -54,42 +54,66 @@ fn show_integrations(state: &BottleState) -> Result<()> {
 
     for detection in &detections {
         let platform = detection.platform;
-        let installed = state.integrations.contains_key(platform.key());
         let detected = detection.detected;
 
-        let status = if installed {
-            style("installed").green()
-        } else if detected {
-            style("detected").yellow()
+        // For Claude Code with multiple directories, show each one
+        if platform == Platform::ClaudeCode && !detection.directories.is_empty() {
+            for dir in &detection.directories {
+                let status = if dir.installed {
+                    style("installed").green()
+                } else {
+                    style("available").yellow()
+                };
+                println!(
+                    "  {:<12} {} {}",
+                    platform.display_name(),
+                    status,
+                    style(format!("({})", dir.display_path)).dim()
+                );
+            }
         } else {
-            style("not detected").dim()
-        };
+            // Original single-line output for other platforms or when no directories detected
+            let installed = state.integrations.contains_key(platform.key());
 
-        let hint = if detected {
-            format!("({})", detection.detection_hint)
-        } else {
-            format!("({} not found)", detection.detection_hint)
-        };
+            let status = if installed {
+                style("installed").green()
+            } else if detected {
+                style("available").yellow()
+            } else {
+                style("not found").dim()
+            };
 
-        println!(
-            "  {:<12} {} {}",
-            platform.display_name(),
-            status,
-            style(hint).dim()
-        );
+            let hint = if detected {
+                format!("({})", detection.detection_hint)
+            } else {
+                format!("({})", detection.detection_hint)
+            };
+
+            println!(
+                "  {:<12} {} {}",
+                platform.display_name(),
+                status,
+                style(hint).dim()
+            );
+        }
     }
 
     println!();
     println!("{}:", style("Commands").dim());
     println!(
-        "  {} {} - Add an integration",
-        style("bottle integrate").cyan(),
-        style("<platform>").dim()
+        "  {} {}",
+        style("bottle integrate <platform>").cyan(),
+        style("Add integration").dim()
     );
     println!(
-        "  {} {} - Remove an integration",
-        style("bottle integrate --remove").cyan(),
-        style("<platform>").dim()
+        "  {} {}",
+        style("bottle integrate --remove <platform>").cyan(),
+        style("Remove integration").dim()
+    );
+    println!(
+        "  {} {}",
+        style("CLAUDE_CONFIG_DIR=~/.claude-work bottle integrate claude_code").cyan(),
+        style("Target other Claude directory").dim()
     );
     println!();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -81,6 +81,9 @@ enum Commands {
     },
 
     /// Add or remove platform integrations (Claude Code, OpenCode, Codex)
+    ///
+    /// Multiple Claude directories? Set CLAUDE_CONFIG_DIR to target a specific one:
+    ///   CLAUDE_CONFIG_DIR=~/.claude-work bottle integrate claude_code
     Integrate {
         /// Platform to integrate: claude_code, opencode, codex
         #[arg(value_enum)]
@@ -162,13 +165,13 @@ enum Commands {
 /// Platform integration targets
 #[derive(Debug, Clone, Copy, ValueEnum)]
 pub enum PlatformArg {
-    /// Claude Code plugin (detected via ~/.claude/)
+    /// Claude Code plugins for ~/.claude (set CLAUDE_CONFIG_DIR to target other directories)
     #[value(name = "claude_code")]
     ClaudeCode,
-    /// OpenCode plugin (detected via opencode.json)
+    /// OpenCode plugins (opencode.json)
     #[value(name = "opencode")]
     OpenCode,
-    /// Codex skill (detected via ~/.codex/)
+    /// Codex skill (~/.codex/)
     #[value(name = "codex")]
     Codex,
 }


### PR DESCRIPTION
## Summary

- Adds detection for multiple Claude Code directories (`~/.claude*`)
- Shows each directory separately in `bottle integrate --list`
- Users can target specific directories via `CLAUDE_CONFIG_DIR` env var

## Example Output

```
$ bottle integrate --list

Platform Integrations:

  Claude Code  installed (~/.claude)
  Claude Code  available (~/.claude-artium)
  Claude Code  available (~/.claude-work)
  OpenCode     available (opencode.json)
  Codex        installed (~/.codex/)

Commands:
  bottle integrate <platform> Add integration
  bottle integrate --remove <platform> Remove integration
  CLAUDE_CONFIG_DIR=~/.claude-work bottle integrate claude_code Target other Claude directory
```

## Test plan

- [ ] Run `bottle integrate --list` with multiple Claude directories
- [ ] Run `CLAUDE_CONFIG_DIR=~/.claude-work bottle integrate --dry-run claude_code`
- [ ] Verify backwards compatibility with default `~/.claude`

🤖 Generated with [Claude Code](https://claude.com/claude-code)